### PR TITLE
makePurchase returns order id on iOS too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This method for Android fetches any pending consumption products.
 		[
 			{
 				platform: "ios" or "android",
+				orderId: transaction identifier for iOS or order id for Android,
 				receipt: purchaseToken or ios receipt as String,
 				productId: "sword001",
 				packageName: "jp.wizcorp.game"
@@ -121,6 +122,7 @@ Upon a successful purchase, the user’s purchase data is cached locally by Goog
 
 		{
 			platform: "ios" or "android",
+			orderId: transaction identifier for iOS or order id for Android,
 			receipt: purchaseToken or ios receipt as String,
 			productId: "sword001",
 			packageName: "jp.wizcorp.game"

--- a/platforms/ios/HelloCordova/Plugins/wizPurchasePlugin/WizPurchasePlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/wizPurchasePlugin/WizPurchasePlugin.m
@@ -318,6 +318,7 @@
                 // We requested this payment let's finish
                 NSDictionary *result = @{
                      @"platform": @"ios",
+                     @"orderId": transaction.transactionIdentifier,
                      @"receipt": receipt,
                      @"productId": transaction.payment.productIdentifier,
                      @"packageName": [[NSBundle mainBundle] bundleIdentifier]
@@ -355,6 +356,7 @@
                 NSString *receipt = [[NSString alloc] initWithData:[transaction transactionReceipt] encoding:NSUTF8StringEncoding];
                 NSDictionary *result = @{
                      @"platform": @"ios",
+                     @"orderId": transaction.transactionIdentifier,
                      @"receipt": receipt,
                      @"productId": transaction.payment.productIdentifier,
                      @"packageName": [[NSBundle mainBundle] bundleIdentifier]


### PR DESCRIPTION
Order id is already returned for Android.
See here: https://github.com/Wizcorp/phonegap-plugin-wizPurchase/blob/master/platforms/android/src/jp/wizcorp/phonegap/plugin/wizPurchase/WizPurchasePlugin.java#L587

poke @ronkorving 