### PR TITLE
iOS receipt update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ A cross-platform mobile application payment API for iOS IAP and Android Billing.
 
 - PhoneGap Version : 3.3
 
-** NOTE: Not currently supporting subscriptions **
+**NOTE:**
+**- Not currently supporting subscriptions.**
+**- Receipts on iOS use API ```appStoreReceiptURL``` available from iOS 7.**
 
 ***A lot of work from the Android side of this plugin must be credited to @[poiuytrez](https://github.com/poiuytrez)'s [AndroidInAppBilling](https://github.com/poiuytrez/AndroidInAppBilling/) plugin. We re-used some plugin class code and all the utility classes, but replaced a lot of the API to be usable in a cross-platform manner with iOS. Many thanks goes to him for his hard work.***
 

--- a/platforms/ios/HelloCordova.xcodeproj/project.pbxproj
+++ b/platforms/ios/HelloCordova.xcodeproj/project.pbxproj
@@ -501,7 +501,7 @@
 					"-ObjC",
 				);
 				PRODUCT_NAME = HelloCordova;
-				PROVISIONING_PROFILE = "C7FE8E28-0AB1-45F2-9977-88091CAD456C";
+				PROVISIONING_PROFILE = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -534,7 +534,7 @@
 					"-ObjC",
 				);
 				PRODUCT_NAME = HelloCordova;
-				PROVISIONING_PROFILE = "C7FE8E28-0AB1-45F2-9977-88091CAD456C";
+				PROVISIONING_PROFILE = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/platforms/ios/HelloCordova/HelloCordova-Info.plist
+++ b/platforms/ios/HelloCordova/HelloCordova-Info.plist
@@ -49,7 +49,7 @@
 		</dict>
 	</dict>
 	<key>CFBundleIdentifier</key>
-	<string>test.mobasaka</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/platforms/ios/HelloCordova/Plugins/wizPurchasePlugin/WizPurchasePlugin.h
+++ b/platforms/ios/HelloCordova/Plugins/wizPurchasePlugin/WizPurchasePlugin.h
@@ -10,11 +10,19 @@
 #import <StoreKit/StoreKit.h>
 #import <Cordova/CDVPlugin.h>
 
+enum CDVWizPurchaseError {
+    NO_ERROR = 0,
+    IOS_VERSION_ERR = 1,
+    INVALID_RECEIPT = 2
+};
+typedef int CDVWizPurchaseError;
+
 @interface WizPurchasePlugin : CDVPlugin <SKProductsRequestDelegate, SKPaymentTransactionObserver> {
     SKProductsResponse *productsResponse;
     NSString *getProductDetailsCb;
     NSString *makePurchaseCb;
     NSString *restorePurchaseCb;
+    NSMutableDictionary *refreshReceiptCallbacks;
 }
 
 - (void)canMakePurchase:(CDVInvokedUrlCommand *)command;

--- a/platforms/ios/HelloCordova/Plugins/wizPurchasePlugin/WizPurchasePlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/wizPurchasePlugin/WizPurchasePlugin.m
@@ -13,6 +13,8 @@
 
 - (CDVPlugin *)initWithWebView:(UIWebView *)theWebView {
 
+    refreshReceiptCallbacks = [[NSMutableDictionary alloc] init];
+
     if (self) {
         // Register ourselves as a transaction observer
         // (we get notified when payments in the payment queue get updated)
@@ -69,9 +71,7 @@
 
 - (void)getPending:(CDVInvokedUrlCommand *)command {
     // Return contents of user defaults
-    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                                       messageAsArray:[self fetchReceipts]];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    [self sendTransactionResults:command.callbackId results:[self fetchReceipts]];
 }
 
 - (void)makePurchase:(CDVInvokedUrlCommand *)command {
@@ -101,6 +101,83 @@
             [self fetchProducts:@[ productId ]];
         }
     }];
+}
+
+- (NSString *)getReceiptString {
+    NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
+    NSData *receiptData = [NSData dataWithContentsOfURL:receiptURL];
+    if (!receiptData) {
+        return nil;
+    }
+    return [receiptData base64EncodedStringWithOptions:0];
+}
+
+- (NSArray *)addReceiptToTransactionResults:(NSString *)receipt results:(NSArray *)results {
+    NSMutableArray *transactionResults = [NSMutableArray arrayWithCapacity:[results count]];
+    for (NSDictionary *result in results) {
+        [transactionResults addObject:[self addReceiptToTransactionResult:receipt result:result]];
+    }
+    return transactionResults;
+}
+
+- (NSDictionary *)addReceiptToTransactionResult:(NSString *)receipt result:(NSDictionary *)result {
+    NSMutableDictionary *resultWithReceipt = [result mutableCopy];
+    [resultWithReceipt setValue:receipt forKey:@"receipt"];
+    return resultWithReceipt;
+}
+
+- (void)getReceipt:(NSString *)callbackId results:(NSArray *)results {
+    NSString *receiptString = [self getReceiptString];
+    if (receiptString) {
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                                      messageAsArray:[self addReceiptToTransactionResults:receiptString results:results]];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+    } else {
+        [self refreshReceipt:callbackId result:results];
+    }
+}
+
+- (void)getReceipt:(NSString *)callbackId result:(NSDictionary *)result {
+    NSString *receiptString = [self getReceiptString];
+    if (receiptString) {
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                                      messageAsDictionary:[self addReceiptToTransactionResult:receiptString result:result]];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+    } else {
+        [self refreshReceipt:callbackId result:result];
+    }
+}
+
+- (void)sendTransactionResult:(NSString *)callbackId result:(NSDictionary *)result {
+    // Best practice of weak linking using the respondsToSelector: cannot be used here
+    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                             messageAsInt:IOS_VERSION_ERR];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+        return;
+    }
+    [self getReceipt:callbackId result:result];
+}
+
+- (void)sendTransactionResults:(NSString *)callbackId results:(NSArray *)results {
+    // Best practice of weak linking using the respondsToSelector: cannot be used here
+    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                             messageAsInt:IOS_VERSION_ERR];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+        return;
+    }
+    [self getReceipt:callbackId results:results];
+}
+
+- (void)refreshReceipt:(NSString *)callbackId result:(id)result {
+    if ([refreshReceiptCallbacks count] > 0) {
+        [refreshReceiptCallbacks setObject:result forKey:callbackId];
+        return;
+    }
+    SKReceiptRefreshRequest *receiptRefreshRequest = [[SKReceiptRefreshRequest alloc] init];
+    receiptRefreshRequest.delegate = self;
+    [receiptRefreshRequest start];
 }
 
 - (void)fetchProducts:(NSArray *)productIdentifiers {
@@ -174,8 +251,53 @@
 
 # pragma Methods for SKProductsRequestDelegate
 
+- (void) requestDidFinish:(SKRequest *)request {
+    if ([request isKindOfClass:[SKReceiptRefreshRequest class]]) {
+        [self receiptRefreshRequestDidFinish:(SKReceiptRefreshRequest *)request];
+    }
+}
+
+- (void) receiptRefreshRequestDidFinish:(SKReceiptRefreshRequest *)request {
+    CDVPluginResult *pluginResult;
+    NSString *receipt = [self getReceiptString];
+    NSArray * keys = [refreshReceiptCallbacks allKeys];
+    if (receipt) {
+        for (NSString *key in keys) {
+            id result = [refreshReceiptCallbacks objectForKey:key];
+            if ([result isKindOfClass:[NSDictionary class]]) {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                             messageAsDictionary:[self addReceiptToTransactionResult:receipt result:result]];
+            } else if ([result isKindOfClass:[NSArray class]]) {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                                  messageAsArray:[self addReceiptToTransactionResults:receipt results:result]];
+            }
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:key];
+        }
+    } else {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                            messageAsInt:INVALID_RECEIPT];
+        for (NSString *key in keys) {
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:key];
+        }
+    }
+    refreshReceiptCallbacks = [[NSMutableDictionary alloc] init];
+}
+
 - (void)request:(SKRequest *)request didFailWithError:(NSError *)error {
     WizLog(@"request - didFailWithError: %@", [[error userInfo] objectForKey:@"NSLocalizedDescription"]);
+    if ([request isKindOfClass:[SKReceiptRefreshRequest class]]) {
+        [self receiptRefreshRequest:(SKReceiptRefreshRequest *)request didFailWithError:error];
+    }
+}
+
+- (void)receiptRefreshRequest:(SKReceiptRefreshRequest *)request didFailWithError:(NSError *)error {
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                      messageAsString:[error localizedDescription]];
+    NSArray * keys = [refreshReceiptCallbacks allKeys];
+    for (NSString *key in keys) {
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:key];
+    }
+    refreshReceiptCallbacks = [[NSMutableDictionary alloc] init];
 }
 
 - (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response {
@@ -231,7 +353,7 @@
         
         NSDictionary *product = NULL;
         NSMutableDictionary *productsDictionary = [[NSMutableDictionary alloc] init];
-        WizLog(@"Products found: %i", [response.products count]);
+        WizLog(@"Products found: %tu", [response.products count]);
         NSString *storeCountry = NULL;
         NSString *storeCurrency = NULL;
         for (SKProduct *obj in response.products) {
@@ -278,10 +400,9 @@
         NSMutableArray *receipts = [[NSMutableArray alloc] init];
         if ([[[SKPaymentQueue defaultQueue] transactions] count] > 0) {
             for (SKPaymentTransaction *transaction in [[SKPaymentQueue defaultQueue] transactions]) {
-                NSString *receipt = [[NSString alloc] initWithData:[transaction transactionReceipt] encoding:NSUTF8StringEncoding];
                 NSDictionary *result = @{
                      @"platform": @"ios",
-                     @"receipt": receipt,
+                     @"orderId": transaction.transactionIdentifier,
                      @"productId": transaction.payment.productIdentifier,
                      @"packageName": [[NSBundle mainBundle] bundleIdentifier]
                 };
@@ -290,10 +411,7 @@
             }
         }
 
-        // Return result to JavaScript
-        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                                           messageAsArray:receipts];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:restorePurchaseCb];
+        [self sendTransactionResults:restorePurchaseCb results:receipts];
         restorePurchaseCb = NULL;
     }
 }
@@ -326,25 +444,17 @@
                 WizLog(@"SKPaymentTransactionStatePurchased");
                 // Immediately save to NSUserDefaults incase we cannot reach JavaScript in time
                 // or connection for server receipt verification is interupted
-                NSString *receipt = [[NSString alloc] initWithData:[transaction transactionReceipt] encoding:NSUTF8StringEncoding];
-                
-                // We requested this payment let's finish
                 NSDictionary *result = @{
-                     @"platform": @"ios",
-                     @"orderId": transaction.transactionIdentifier,
-                     @"receipt": receipt,
-                     @"productId": transaction.payment.productIdentifier,
-                     @"packageName": [[NSBundle mainBundle] bundleIdentifier]
-                };
+                                         @"platform": @"ios",
+                                         @"orderId": transaction.transactionIdentifier,
+                                         @"productId": transaction.payment.productIdentifier,
+                                         @"packageName": [[NSBundle mainBundle] bundleIdentifier]
+                                         };
                 
                 [self backupReceipt:result];
 
                 if (makePurchaseCb) {
-                   
-                    // Return result to JavaScript
-                    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                                                  messageAsDictionary:result];
-                    [self.commandDelegate sendPluginResult:pluginResult callbackId:makePurchaseCb];
+                    [self sendTransactionResult:makePurchaseCb result:result];
                     makePurchaseCb = NULL;
                 }
                 break;
@@ -353,7 +463,7 @@
             
 				error = transaction.error.localizedDescription;
 				errorCode = transaction.error.code;
-				WizLog(@"SKPaymentTransactionStateFailed %d %@", errorCode, error);
+				WizLog(@"SKPaymentTransactionStateFailed %zd %@", errorCode, error);
                 if (makePurchaseCb) {
                     // Return result to JavaScript
                     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
@@ -366,11 +476,9 @@
 			case SKPaymentTransactionStateRestored: {
                 // We restored some non-consumable transactions add to receipt backup
 				WizLog(@"SKPaymentTransactionStateRestored");
-                NSString *receipt = [[NSString alloc] initWithData:[transaction transactionReceipt] encoding:NSUTF8StringEncoding];
                 NSDictionary *result = @{
                      @"platform": @"ios",
                      @"orderId": transaction.transactionIdentifier,
-                     @"receipt": receipt,
                      @"productId": transaction.payment.productIdentifier,
                      @"packageName": [[NSBundle mainBundle] bundleIdentifier]
                 };

--- a/platforms/ios/HelloCordova/Plugins/wizPurchasePlugin/WizPurchasePlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/wizPurchasePlugin/WizPurchasePlugin.m
@@ -12,10 +12,10 @@
 @implementation WizPurchasePlugin
 
 - (CDVPlugin *)initWithWebView:(UIWebView *)theWebView {
-
-    refreshReceiptCallbacks = [[NSMutableDictionary alloc] init];
-
+    self = [super init];
     if (self) {
+        refreshReceiptCallbacks = [[NSMutableDictionary alloc] init];
+
         // Register ourselves as a transaction observer
         // (we get notified when payments in the payment queue get updated)
         [[SKPaymentQueue defaultQueue] addTransactionObserver:self];

--- a/platforms/ios/HelloCordova/Plugins/wizPurchasePlugin/WizPurchasePlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/wizPurchasePlugin/WizPurchasePlugin.m
@@ -126,7 +126,7 @@
     return resultWithReceipt;
 }
 
-- (void)getReceipt:(NSString *)callbackId results:(NSArray *)results {
+- (void)sendTransactionResultsWithReceipt:(NSString *)callbackId results:(NSArray *)results {
     NSString *receiptString = [self getReceiptString];
     if (receiptString) {
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
@@ -137,7 +137,7 @@
     }
 }
 
-- (void)getReceipt:(NSString *)callbackId result:(NSDictionary *)result {
+- (void)sendTransactionResultWithReceipt:(NSString *)callbackId result:(NSDictionary *)result {
     NSString *receiptString = [self getReceiptString];
     if (receiptString) {
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
@@ -156,7 +156,7 @@
         [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
         return;
     }
-    [self getReceipt:callbackId result:result];
+    [self sendTransactionResultWithReceipt:callbackId result:result];
 }
 
 - (void)sendTransactionResults:(NSString *)callbackId results:(NSArray *)results {
@@ -167,12 +167,13 @@
         [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
         return;
     }
-    [self getReceipt:callbackId results:results];
+    [self sendTransactionResultsWithReceipt:callbackId results:results];
 }
 
 - (void)refreshReceipt:(NSString *)callbackId result:(id)result {
-    if ([refreshReceiptCallbacks count] > 0) {
-        [refreshReceiptCallbacks setObject:result forKey:callbackId];
+    [refreshReceiptCallbacks setObject:result forKey:callbackId];
+    // If there is more than one refresh receipt callback waiting it means a receipt refresh request was already sent
+    if ([refreshReceiptCallbacks count] > 1) {
         return;
     }
     SKReceiptRefreshRequest *receiptRefreshRequest = [[SKReceiptRefreshRequest alloc] init];

--- a/platforms/ios/HelloCordova/Plugins/wizPurchasePlugin/WizPurchasePlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/wizPurchasePlugin/WizPurchasePlugin.m
@@ -11,16 +11,12 @@
 
 @implementation WizPurchasePlugin
 
-- (CDVPlugin *)initWithWebView:(UIWebView *)theWebView {
-    self = [super init];
-    if (self) {
-        refreshReceiptCallbacks = [[NSMutableDictionary alloc] init];
+- (void)pluginInitialize {
+    refreshReceiptCallbacks = [[NSMutableDictionary alloc] init];
 
-        // Register ourselves as a transaction observer
-        // (we get notified when payments in the payment queue get updated)
-        [[SKPaymentQueue defaultQueue] addTransactionObserver:self];
-    }
-    return self;
+    // Register ourselves as a transaction observer
+    // (we get notified when payments in the payment queue get updated)
+    [[SKPaymentQueue defaultQueue] addTransactionObserver:self];
 }
 
 - (BOOL)canMakePurchase {
@@ -288,7 +284,7 @@
             [self.commandDelegate sendPluginResult:pluginResult callbackId:key];
         }
     }
-    refreshReceiptCallbacks = [[NSMutableDictionary alloc] init];
+    [refreshReceiptCallbacks removeAllObjects];
 }
 
 - (void)request:(SKRequest *)request didFailWithError:(NSError *)error {
@@ -305,7 +301,7 @@
     for (NSString *key in keys) {
         [self.commandDelegate sendPluginResult:pluginResult callbackId:key];
     }
-    refreshReceiptCallbacks = [[NSMutableDictionary alloc] init];
+    [refreshReceiptCallbacks removeAllObjects];
 }
 
 - (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response {

--- a/platforms/ios/www/phonegap/plugin/wizPurchasePlugin/WizPurchaseError.js
+++ b/platforms/ios/www/phonegap/plugin/wizPurchasePlugin/WizPurchaseError.js
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Wizcorp Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+*/
+
+/**
+ * WizPurchaseError
+ */
+function WizPurchaseError(error) {
+  this.code = error || null;
+}
+
+// WizPurchase error codes
+WizPurchaseError.IOS_VERSION_ERR = 1;
+WizPurchaseError.INVALID_RECEIPT = 2;
+
+module.exports = WizPurchaseError;

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,6 +18,9 @@
     <js-module src="www/phonegap/plugin/wizPurchasePlugin/wizPurchasePlugin.js" name="wizPurchase" target="phonegap/plugin/wizPurchase/wizPurchase.js">
         <clobbers target="window.wizPurchase" />
     </js-module>
+    <js-module src="www/phonegap/plugin/wizPurchasePlugin/WizPurchaseError.js" name="WizPurchaseError" target="phonegap/plugin/wizPurchase/WizPurchaseError.js">
+        <clobbers target="window.WizPurchaseError" />
+    </js-module>
 
     <!-- ios -->
     <platform name="ios">

--- a/www/phonegap/plugin/wizPurchasePlugin/WizPurchaseError.js
+++ b/www/phonegap/plugin/wizPurchasePlugin/WizPurchaseError.js
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Wizcorp Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+*/
+
+/**
+ * WizPurchaseError
+ */
+function WizPurchaseError(error) {
+  this.code = error || null;
+}
+
+// WizPurchase error codes
+WizPurchaseError.IOS_VERSION_ERR = 1;
+WizPurchaseError.INVALID_RECEIPT = 2;
+
+module.exports = WizPurchaseError;


### PR DESCRIPTION
We now use on iOS the global app receipt available from iOS 7. Therefore, theses changes remove compatibility with iOS versions previous 7.

poke @ronkorving 