### PR TITLE
Specify billing key at plugin install or in config.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,19 @@ A cross-platform mobile application payment API for iOS IAP and Android Billing.
 
 ***A lot of work from the Android side of this plugin must be credited to @[poiuytrez](https://github.com/poiuytrez)'s [AndroidInAppBilling](https://github.com/poiuytrez/AndroidInAppBilling/) plugin. We re-used some plugin class code and all the utility classes, but replaced a lot of the API to be usable in a cross-platform manner with iOS. Many thanks goes to him for his hard work.***
 
-## Install (with Plugman)
+## Install
 
-	cordova plugin add https://github.com/wizcorp/phonegap-plugin-wizPurchase
-	cordova build
-	
-	< or >
-	
-	phonegap local plugin add https://github.com/wizcorp/phonegap-plugin-wizPurchase
-	phonegap build
+### via CLI
+
+	cordova plugin add https://github.com/Wizcorp/phonegap-plugin-wizPurchase --variable BILLING_KEY="YOUR_BILLING_KEY"
+
+### via config.xml
+
+	<plugin name="jp.wizcorp.phonegap.plugin.wizPurchase" spec="https://github.com/Wizcorp/phonegap-plugin-wizPurchase">
+	    <variable name="BILLING_KEY" value="YOUR_BILLING_KEY" />
+	</plugin>
+
+You need to specify your billing key **only** if you need Android support.
 
 ## Setup
 
@@ -32,8 +36,6 @@ A cross-platform mobile application payment API for iOS IAP and Android Billing.
 - Make sure your application has a version number (do not leave it blank).
 
 #### Android
-
-- Add your Billing Key to `res/values/billing_key.xml` (this can be found in the Google Play Developer Console).
 
 - Set `debuggable` to `false` and upload a signed version of you application to the Google Play Developer Console.
 

--- a/platforms/android/res/values/billing_key.xml
+++ b/platforms/android/res/values/billing_key.xml
@@ -1,4 +1,3 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-	<string name="billing_key"></string>
 </resources>

--- a/plugin.xml
+++ b/plugin.xml
@@ -42,6 +42,7 @@
 
     <!-- android -->
     <platform name="android">
+        <preference name="BILLING_KEY"/>
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="wizPurchasePlugin" >
@@ -84,6 +85,9 @@
         <!-- Billing Key String Holder -->
         <source-file src="platforms/android/res/values/billing_key.xml"
                 target-dir="res/values/"/>
+        <config-file target="res/values/billing_key.xml" parent="/*">
+            <string name="billing_key">$BILLING_KEY</string>
+        </config-file>
     </platform>
 
 </plugin>


### PR DESCRIPTION
Billing key for Android no longer needs to be added manually in ```billing_key.xml``` file. It can either be specified at plugin install ```plugin add ... ``` or directly in the configuration file ```config.xml```.

poke @ronkorving and @aogilvie 